### PR TITLE
Correct times for May 14 in bonus_module_calendar.md

### DIFF
--- a/_extras/bonus_module_calendar.md
+++ b/_extras/bonus_module_calendar.md
@@ -47,7 +47,7 @@ This workshop will be hands-on and interactive.
 <br><br>
 
 * [May 14, 2021 - 9 am North American Eastern Daylight Time](https://www.eventbrite.com/e/bonus-module-teaching-online-may-14-north-american-eastern-daylight-time-tickets-147847785707): This event will run for 3 hours. 
-    - 10 am North American Pacific Daylight Time 
+    - 6 am North American Pacific Daylight Time 
     - 2 pm Western European Summer Time
     - 3 pm Central European Summer Time 
     - *See the start time in [your local time zone](https://www.timeanddate.com/worldclock/fixedtime.html?iso=20210514T09&p1=179)*

--- a/_extras/bonus_module_calendar.md
+++ b/_extras/bonus_module_calendar.md
@@ -48,9 +48,9 @@ This workshop will be hands-on and interactive.
 
 * [May 14, 2021 - 9 am North American Eastern Daylight Time](https://www.eventbrite.com/e/bonus-module-teaching-online-may-14-north-american-eastern-daylight-time-tickets-147847785707): This event will run for 3 hours. 
     - 10 am North American Pacific Daylight Time 
-    - 6 pm Western European Summer Time
-    - 7 pm Central European Summer Time 
-    - *See the start time in [your local time zone](https://www.timeanddate.com/worldclock/fixedtime.html?iso=20210514T13&p1=179)*
+    - 2 pm Western European Summer Time
+    - 3 pm Central European Summer Time 
+    - *See the start time in [your local time zone](https://www.timeanddate.com/worldclock/fixedtime.html?iso=20210514T09&p1=179)*
 <br><br>
 
 * [June 4, 2021 - 9 am Central European Summer Time](https://www.eventbrite.com/e/bonus-module-teaching-online-june-4-central-european-time-tickets-147846864953): This event will run for 3 hours.


### PR DESCRIPTION
The link to timeanddate.com was for 13:00 EDT, which was then reflected in the times for WEST/BST/IST and CEST.

This fix corrects the information for 09:00 EDT.